### PR TITLE
String interpolation in Swift is a cinch because you don't have to us…

### DIFF
--- a/Print.playground/Contents.swift
+++ b/Print.playground/Contents.swift
@@ -1,6 +1,6 @@
-var favoriteWord = "mercurial"    // Use your own favorite word!
-var favoriteColor = "blue"        // Use your own favorite color!
-var favoriteMusician = "Nirvana"  // Use your own favorite musician!
+var favoriteWord = "petrichor"    // Use your own favorite word!
+var favoriteColor = "seafoam green"        // Use your own favorite color!
+var favoriteMusician = "Stevie Wonder"  // Use your own favorite musician!
 
 print(favoriteWord)
 print(favoriteColor)
@@ -17,3 +17,18 @@ print("Hi Mom! My favorite word is \(favoriteWord), my favorite color is \(favor
 
 var skySentence = "The sky is \(color)."
 print(skySentence)
+
+var favoriteCereal = "Cheerios"
+var favoriteFruit = "Blueberries"
+var favoritePodcast = "Radiolab"
+
+print("I love starting the day with a bowl of \(favoriteCereal) topped with fresh \(favoriteFruit) and tuning in to the \(favoritePodcast) podcast.")
+
+let name = "Jim"
+var greetInstructor = "What up, \(name)? Let your Swift nerd flag fly!"
+
+var numberOfPeopleInNYC = 8406000
+
+// Does the same interpolation format work for other types? YES! In this case we are interpolating an integer into a string... This would require a different format specifier in Objective C.
+var populationSentence = "The population of New York City in 2013 was \(numberOfPeopleInNYC) people."
+print(populationSentence)


### PR DESCRIPTION
…e format specifiers woot wooooooo